### PR TITLE
Fix invalid table alias for nested filters

### DIFF
--- a/src/lib/query-builder/meta.ts
+++ b/src/lib/query-builder/meta.ts
@@ -163,6 +163,7 @@ export const toMeta = (
 
       const metaFilters: TT.MetaFilter[] = [];
       let aaIdx = aliasIdx;
+      let hasNestedFilters = false;
       Object.entries(filters)
         .filter(([_k, v]) => v !== undefined)
         .forEach(([fieldName, pvalue]) => {
@@ -183,6 +184,7 @@ export const toMeta = (
               depth + 1
             );
             aaIdx++;
+            hasNestedFilters = true;
             return;
           }
 
@@ -199,7 +201,8 @@ export const toMeta = (
           );
         });
 
-      if (metaFilters.length > 0) {
+      // Add unit if there are direct filters OR if this entity is needed for nested filter joins
+      if (metaFilters.length > 0 || (hasNestedFilters && join !== undefined)) {
         // find an array element with the same join object
         const fFilter = ry.findIndex((x) => UU.compareJoins(join, x));
 

--- a/src/lib/query-builder/meta3.test.ts
+++ b/src/lib/query-builder/meta3.test.ts
@@ -206,3 +206,35 @@ test("multi filters", () => {
 
   expect(s).toEqual(ss);
 });
+
+// Bug test for issue #45: deploy is in filters but NOT in projection
+test("multi filters - nested filter without projection", () => {
+  const q = {
+    EnvVar: {
+      projection: { key: true, value: true }, // NOT including service.deploy
+      filters: {
+        product: { id: 2 },
+        service: { deploy: { id: 19 } }, // But filtering by it
+        instance: { uuid: "2c5d0535-26ab-11e9-9284-fa163e41f33d" },
+      },
+    },
+  };
+
+  const entity = "EnvVar";
+
+  const em = M.toMeta(entity, q[entity], model);
+  const s = S.toQuery(em, "MySQL");
+
+  // Expected: should still include JOIN to service_deploy for filtering
+  const ss = [
+    "SELECT t0.`id` AS t0_id, t0.`keyy` AS t0_key, t0.`value` AS t0_value, t1.`id` AS t1_id, t2.`uuid` AS t2_uuid, t3.`id` AS t3_id, t4.`uuid` AS t4_uuid",
+    "FROM product_env_var AS t0",
+    "JOIN product AS t1 ON t1.id=t0.product_id",
+    "LEFT JOIN product_service AS t2 ON t2.id=t0.service_id",
+    "LEFT JOIN service_deploy AS t3 ON t3.id=t2.deploy_id",
+    "JOIN instance AS t4 ON t4.id=t0.instance_id",
+    "WHERE t1.`id`=2 AND t3.`id`=19 AND t4.`uuid`='2c5d0535-26ab-11e9-9284-fa163e41f33d'",
+  ];
+
+  expect(s).toEqual(ss);
+});


### PR DESCRIPTION
Fixes #45

Ensures intermediate entities in filter chains are added to query units even if they have no direct filters, preventing invalid t-1 table aliases.