### PR TITLE
Fix setting null for optional datetime fields

### DIFF
--- a/src/lib/query-builder/mutate.test.ts
+++ b/src/lib/query-builder/mutate.test.ts
@@ -307,6 +307,40 @@ describe("update with null", () => {
     );
   });
 
+  // Test for issue #58: setting optional datetime to null
+  test("update optional datetime to null", () => {
+    const testModel: T.Entity[] = [
+      {
+        name: "Event",
+        uuid: false,
+        fields: [
+          { name: "title", type: "String", optional: false },
+          { name: "startDate", type: "LocalDateTime", optional: false },
+          { name: "endDate", type: "LocalDateTime", optional: true }, // optional datetime
+        ],
+      },
+    ];
+
+    const q = {
+      Event: {
+        update: {
+          data: {
+            endDate: null,
+          },
+          filters: {
+            id: 123,
+          },
+        },
+      },
+    };
+
+    const [t] = S.createMutateQuery(q, testModel, databaseType);
+
+    expect(t.sql).toEqual(
+      "UPDATE event SET `end_date`=NULL WHERE `id`=123;"
+    );
+  });
+
   test("update a value to null, forbidden", () => {
     const q = {
       Module: {

--- a/src/lib/query-builder/mutate.ts
+++ b/src/lib/query-builder/mutate.ts
@@ -221,6 +221,11 @@ const toQueryUpdate = (
 
       const col = sep + U.fieldToColumn(field) + sep;
 
+      // Check if value should be NULL for optional fields
+      if (UU.isNull(field.optional, v)) {
+        return col + "=NULL";
+      }
+
       if (!U.isStandardType(field.type)) {
         // if same entity, do not link extra table
         if (field.type === entity.name && (v as { id: number }).id) {


### PR DESCRIPTION
Fixes #58

Adds null check before calling formatSQL() in update queries to prevent optional datetime fields being set to epoch date instead of NULL.